### PR TITLE
Centos7 MVN war plugin version change

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -138,7 +138,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1-beta-1</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <id>create-skinny-war</id>


### PR DESCRIPTION
As of newser MVN the beta-1 is now obsolete

Signed-off-by: Patrick Kirsch pkirsch@zscho.de
